### PR TITLE
Add WithGaugeTags method to support arbitrary tags on envelopes

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -197,15 +197,13 @@ func WithGaugeValue(name string, value float64, unit string) EmitGaugeOption {
 // and will overwrite if called a second time.
 func WithGaugeTags(tags map[string]string) EmitGaugeOption {
 	return func(e *loggregator_v2.Envelope) {
-		valueTags := make(map[string]*loggregator_v2.Value, 0)
 		for name, value := range tags {
-			valueTags[name] = &loggregator_v2.Value{
+			e.Tags[name] = &loggregator_v2.Value{
 				Data: &loggregator_v2.Value_Text{
 					Text: value,
 				},
 			}
 		}
-		e.Tags = valueTags
 	}
 }
 
@@ -220,6 +218,7 @@ func (c *Client) EmitGauge(opts ...EmitGaugeOption) {
 				Metrics: make(map[string]*loggregator_v2.GaugeValue),
 			},
 		},
+		Tags: make(map[string]*loggregator_v2.Value),
 	}
 
 	for _, o := range opts {

--- a/v2/client.go
+++ b/v2/client.go
@@ -30,7 +30,6 @@ import (
 
 	"code.cloudfoundry.org/go-loggregator/internal/loggregator_v2"
 	"golang.org/x/net/context"
-	"errors"
 )
 
 // Client represents an emitter into loggregator. It should be created with the
@@ -196,59 +195,17 @@ func WithGaugeValue(name string, value float64, unit string) EmitGaugeOption {
 // WithGaugeTags adds tag information that can be text, integer, or decimal to
 // the envelope.  WithGaugeTags expects a single call with a complete map
 // and will overwrite if called a second time.
-func WithGaugeTags(tags map[string]interface{}) (EmitGaugeOption, error) {
-	err := checkValues(tags)
+func WithGaugeTags(tags map[string]string) EmitGaugeOption {
 	return func(e *loggregator_v2.Envelope) {
 		valueTags := make(map[string]*loggregator_v2.Value, 0)
 		for name, value := range tags {
-			data, err := toValue(value)
-			if err != nil {
-
+			valueTags[name] = &loggregator_v2.Value{
+				Data: &loggregator_v2.Value_Text{
+					Text: value,
+				},
 			}
-			valueTags[name] = data
 		}
 		e.Tags = valueTags
-	}, err
-}
-
-func checkValues(tags map[string]interface{}) error {
-	for _, value := range tags {
-		switch value.(type) {
-		case string:
-			break
-		case int64:
-			break
-		case float64:
-			break
-		default:
-			return errors.New("Tag Values must conform to loggregator_v2.Value isValueData interface.")
-		}
-	}
-	return nil
-}
-
-func toValue(value interface{}) (*loggregator_v2.Value, error) {
-	switch value.(type) {
-	case string:
-		return &loggregator_v2.Value{
-			Data: &loggregator_v2.Value_Text{
-				Text: value.(string),
-			},
-		}, nil
-	case int64:
-		return &loggregator_v2.Value{
-			Data: &loggregator_v2.Value_Integer{
-				Integer: value.(int64),
-			},
-		}, nil
-	case float64:
-		return &loggregator_v2.Value{
-			Data: &loggregator_v2.Value_Decimal{
-				Decimal: value.(float64),
-			},
-		}, nil
-	default:
-		return nil, errors.New("Tag Values must conform to loggregator_v2.Value isValueData interface.")
 	}
 }
 

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -105,17 +105,10 @@ var _ = Describe("GrpcClient", func() {
 	})
 
 	It("sends app metrics", func() {
-		tags := make(map[string]interface{}, 3)
-		tags["tag-text"] = "tag-value"
-		tags["tag-int"] = int64(42)
-		tags["tag-dec"] = float64(1.25)
-
-		tagOption, err := v2.WithGaugeTags(tags)
-		Expect(err).ToNot(HaveOccurred())
 		client.EmitGauge(
 			v2.WithGaugeValue("name-a", 1, "unit-a"),
 			v2.WithGaugeValue("name-b", 2, "unit-b"),
-			tagOption,
+			v2.WithGaugeTags(map[string]string{"some-tag":"some-tag-value"}),
 			v2.WithGaugeAppInfo("app-id"),
 		)
 
@@ -130,9 +123,7 @@ var _ = Describe("GrpcClient", func() {
 		Expect(metrics.GetMetrics()).To(HaveLen(2))
 		Expect(metrics.GetMetrics()["name-a"].Value).To(Equal(1.0))
 		Expect(metrics.GetMetrics()["name-b"].Value).To(Equal(2.0))
-		Expect(env.Tags["tag-text"].GetText()).To(Equal("tag-value"))
-		Expect(env.Tags["tag-int"].GetInteger()).To(Equal(int64(42)))
-		Expect(env.Tags["tag-dec"].GetDecimal()).To(Equal(float64(1.25)))
+		Expect(env.Tags["some-tag"].GetText()).To(Equal("some-tag-value"))
 	})
 
 	It("reconnects when the server goes away and comes back", func() {

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -105,9 +105,17 @@ var _ = Describe("GrpcClient", func() {
 	})
 
 	It("sends app metrics", func() {
+		tags := make(map[string]interface{}, 3)
+		tags["tag-text"] = "tag-value"
+		tags["tag-int"] = int64(42)
+		tags["tag-dec"] = float64(1.25)
+
+		tagOption, err := v2.WithGaugeTags(tags)
+		Expect(err).ToNot(HaveOccurred())
 		client.EmitGauge(
 			v2.WithGaugeValue("name-a", 1, "unit-a"),
 			v2.WithGaugeValue("name-b", 2, "unit-b"),
+			tagOption,
 			v2.WithGaugeAppInfo("app-id"),
 		)
 
@@ -122,6 +130,9 @@ var _ = Describe("GrpcClient", func() {
 		Expect(metrics.GetMetrics()).To(HaveLen(2))
 		Expect(metrics.GetMetrics()["name-a"].Value).To(Equal(1.0))
 		Expect(metrics.GetMetrics()["name-b"].Value).To(Equal(2.0))
+		Expect(env.Tags["tag-text"].GetText()).To(Equal("tag-value"))
+		Expect(env.Tags["tag-int"].GetInteger()).To(Equal(int64(42)))
+		Expect(env.Tags["tag-dec"].GetDecimal()).To(Equal(float64(1.25)))
 	})
 
 	It("reconnects when the server goes away and comes back", func() {


### PR DESCRIPTION
We didn't know if it was reasonable to expect a user to pass in a map[string]*loggregator_v2.Value so we made it take a map[string]interface{} and used a type switch to turn it into Value.  Neither one of us has any prior experience using generic tools in golang.  Brutally honest review would be appreciated.

The primary problem we can see with what we did here is that allowing the user to pass arbitrary interface means we have to choose between swallowing unaccepted types and surfacing errors.  Surfacing errors really conflicts with the pattern established here for how options are applied to envelopes.

Signed-off-by: Travis Longoria <tlongoria@pivotal.io>