### PR TITLE
Add support for arbitrary tags

### DIFF
--- a/client.go
+++ b/client.go
@@ -87,7 +87,11 @@ func NewV2Client(config Config) (Client, error) {
 		return nil, err
 	}
 
-	var opts []v2.Option
+	opts := []v2.Option{
+		// Whereas Metron will add tags for deployment, name, index, and ip,
+		// it does not add job origin and so we must add it manually here.
+		v2.WithTag("origin", config.JobOrigin),
+	}
 
 	if config.BatchMaxSize != 0 {
 		opts = append(opts, v2.WithBatchMaxSize(config.BatchMaxSize))

--- a/v2/client.go
+++ b/v2/client.go
@@ -38,6 +38,7 @@ type Client struct {
 	conn      loggregator_v2.IngressClient
 	sender    loggregator_v2.Ingress_BatchSenderClient
 	envelopes chan *loggregator_v2.Envelope
+	tags      map[string]string
 
 	batchMaxSize       uint
 	batchFlushInterval time.Duration
@@ -48,6 +49,14 @@ type Client struct {
 
 // Option is the type of a configurable client option.
 type Option func(*Client)
+
+// WithTag allows for the configuration of arbitrary metadata which will be
+// included in all data sent to Loggregator
+func WithTag(name, value string) Option {
+	return func(c *Client) {
+		c.tags[name] = value
+	}
+}
 
 // WithBatchMaxSize allows for the configuration of the number of messages to
 // collect before emitting them into loggregator. By default, its value is 100
@@ -100,6 +109,7 @@ func WithLogger(l Logger) Option {
 func NewClient(tlsConfig *tls.Config, opts ...Option) (*Client, error) {
 	client := &Client{
 		envelopes:          make(chan *loggregator_v2.Envelope, 100),
+		tags:               make(map[string]string),
 		batchMaxSize:       100,
 		batchFlushInterval: time.Second,
 		port:               3458,
@@ -132,11 +142,11 @@ func WithAppInfo(appID, sourceType, sourceInstance string) EmitLogOption {
 	return func(e *loggregator_v2.Envelope) {
 		e.SourceId = appID
 		e.InstanceId = sourceInstance
-
-		// TODO: don't blow away the tags
-		e.Tags = map[string]*loggregator_v2.Value{
-			"source_type":     &loggregator_v2.Value{Data: &loggregator_v2.Value_Text{Text: sourceType}},
-			"source_instance": &loggregator_v2.Value{Data: &loggregator_v2.Value_Text{Text: sourceInstance}},
+		e.Tags["source_type"] = &loggregator_v2.Value{
+			Data: &loggregator_v2.Value_Text{Text: sourceType},
+		}
+		e.Tags["source_instance"] = &loggregator_v2.Value{
+			Data: &loggregator_v2.Value_Text{Text: sourceInstance},
 		}
 	}
 }
@@ -159,6 +169,13 @@ func (c *Client) EmitLog(message string, opts ...EmitLogOption) {
 				Type:    loggregator_v2.Log_ERR,
 			},
 		},
+		Tags: make(map[string]*loggregator_v2.Value),
+	}
+
+	for k, v := range c.tags {
+		e.Tags[k] = &loggregator_v2.Value{
+			Data: &loggregator_v2.Value_Text{Text: v},
+		}
 	}
 
 	for _, o := range opts {
@@ -219,6 +236,12 @@ func (c *Client) EmitGauge(opts ...EmitGaugeOption) {
 			},
 		},
 		Tags: make(map[string]*loggregator_v2.Value),
+	}
+
+	for k, v := range c.tags {
+		e.Tags[k] = &loggregator_v2.Value{
+			Data: &loggregator_v2.Value_Text{Text: v},
+		}
 	}
 
 	for _, o := range opts {

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -41,6 +41,7 @@ var _ = Describe("GrpcClient", func() {
 			tlsConfig,
 			v2.WithPort(server.Port()),
 			v2.WithBatchFlushInterval(50*time.Millisecond),
+			v2.WithTag("origin", "some-origin"),
 		)
 	})
 
@@ -78,6 +79,7 @@ var _ = Describe("GrpcClient", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(env.Tags["source_instance"].GetText()).To(Equal("source-instance"))
+		Expect(env.Tags["origin"].GetText()).To(Equal("some-origin"))
 		Expect(env.SourceId).To(Equal("app-id"))
 		Expect(env.InstanceId).To(Equal("source-instance"))
 
@@ -114,7 +116,7 @@ var _ = Describe("GrpcClient", func() {
 		client.EmitGauge(
 			v2.WithGaugeValue("name-a", 1, "unit-a"),
 			v2.WithGaugeValue("name-b", 2, "unit-b"),
-			v2.WithGaugeTags(map[string]string{"some-tag":"some-tag-value"}),
+			v2.WithGaugeTags(map[string]string{"some-tag": "some-tag-value"}),
 			v2.WithGaugeAppInfo("app-id"),
 		)
 
@@ -130,6 +132,7 @@ var _ = Describe("GrpcClient", func() {
 		Expect(metrics.GetMetrics()["name-a"].Value).To(Equal(1.0))
 		Expect(metrics.GetMetrics()["name-b"].Value).To(Equal(2.0))
 		Expect(env.Tags["some-tag"].GetText()).To(Equal("some-tag-value"))
+		Expect(env.Tags["origin"].GetText()).To(Equal("some-origin"))
 	})
 
 	It("reconnects when the server goes away and comes back", func() {


### PR DESCRIPTION
Aside from the feature named in the title, this commit also restores the origin tag previously used in v1.0.0, which is required by Diego.