### PR TITLE
Split NewTLSConfig into ingress and egress

### DIFF
--- a/compatibility/client.go
+++ b/compatibility/client.go
@@ -80,7 +80,7 @@ func NewV1IngressClient(config Config) (IngressClient, error) {
 // Deprecated: NewV2IngressClient will be removed in the next major version.
 // Instead, use v2.NewIngressClient.
 func NewV2IngressClient(config Config) (IngressClient, error) {
-	tlsConfig, err := v2.NewTLSConfig(
+	tlsConfig, err := v2.NewIngressTLSConfig(
 		config.CACertPath,
 		config.CertPath,
 		config.KeyPath,

--- a/examples/runtime_stats/main.go
+++ b/examples/runtime_stats/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	tlsConfig, err := loggregator.NewTLSConfig(
+	tlsConfig, err := loggregator.NewIngressTLSConfig(
 		os.Getenv("CA_CERT_PATH"),
 		os.Getenv("CERT_PATH"),
 		os.Getenv("KEY_PATH"),
@@ -21,7 +21,7 @@ func main() {
 
 	client, err := loggregator.NewIngressClient(
 		tlsConfig,
-		loggregator.WithPort(3458),
+		loggregator.WithAddr("localhost:3458"),
 		loggregator.WithLogger(log.New(os.Stdout, "", log.LstdFlags)),
 	)
 

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	tlsConfig, err := loggregator.NewTLSConfig(
+	tlsConfig, err := loggregator.NewIngressTLSConfig(
 		os.Getenv("CA_CERT_PATH"),
 		os.Getenv("CERT_PATH"),
 		os.Getenv("KEY_PATH"),
@@ -19,7 +19,7 @@ func main() {
 
 	client, err := loggregator.NewIngressClient(
 		tlsConfig,
-		loggregator.WithPort(3458),
+		loggregator.WithAddr("localhost:3458"),
 	)
 
 	if err != nil {

--- a/ingress_client_test.go
+++ b/ingress_client_test.go
@@ -31,7 +31,7 @@ var _ = Describe("IngressClient", func() {
 
 		receivers = server.Receivers()
 
-		tlsConfig, err := loggregator.NewTLSConfig(
+		tlsConfig, err := loggregator.NewIngressTLSConfig(
 			fixture("CA.crt"),
 			fixture("client.crt"),
 			fixture("client.key"),

--- a/tls.go
+++ b/tls.go
@@ -7,14 +7,14 @@ import (
 	"io/ioutil"
 )
 
-// NewTLSConfig provides a convenient means for creating a *tls.Config
-// which uses the CA, cert, and key.
+// NewIngressTLSConfig provides a convenient means for creating a *tls.Config
+// which uses the CA, cert, and key for the ingress endpoint.
 func NewIngressTLSConfig(caPath, certPath, keyPath string) (*tls.Config, error) {
 	return newTLSConfig(caPath, certPath, keyPath, "metron")
 }
 
-// NewTLSConfig provides a convenient means for creating a *tls.Config
-// which uses the CA, cert, and key.
+// NewEgressTLSConfig provides a convenient means for creating a *tls.Config
+// which uses the CA, cert, and key for the egress endpoint.
 func NewEgressTLSConfig(caPath, certPath, keyPath string) (*tls.Config, error) {
 	return newTLSConfig(caPath, certPath, keyPath, "reverselogproxy")
 }

--- a/tls.go
+++ b/tls.go
@@ -9,14 +9,24 @@ import (
 
 // NewTLSConfig provides a convenient means for creating a *tls.Config
 // which uses the CA, cert, and key.
-func NewTLSConfig(caPath, certPath, keyPath string) (*tls.Config, error) {
+func NewIngressTLSConfig(caPath, certPath, keyPath string) (*tls.Config, error) {
+	return newTLSConfig(caPath, certPath, keyPath, "metron")
+}
+
+// NewTLSConfig provides a convenient means for creating a *tls.Config
+// which uses the CA, cert, and key.
+func NewEgressTLSConfig(caPath, certPath, keyPath string) (*tls.Config, error) {
+	return newTLSConfig(caPath, certPath, keyPath, "reverselogproxy")
+}
+
+func newTLSConfig(caPath, certPath, keyPath, cn string) (*tls.Config, error) {
 	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 	if err != nil {
 		return nil, err
 	}
 
 	tlsConfig := &tls.Config{
-		ServerName:         "metron",
+		ServerName:         cn,
 		Certificates:       []tls.Certificate{cert},
 		InsecureSkipVerify: false,
 	}


### PR DESCRIPTION
- Adds NewIngressTLSConfig() and NewEgressTLSConfig()
- Fixes examples