### PR TITLE
Adds a method to increment counter with dela to IngressClient and its implementations

### DIFF
--- a/compatibility/client.go
+++ b/compatibility/client.go
@@ -28,6 +28,7 @@ type IngressClient interface {
 	SendBytesPerSecond(name string, value float64) error
 	SendRequestsPerSecond(name string, value float64) error
 	IncrementCounter(name string) error
+	IncrementCounterWithDelta(name string, value uint64) error
 	SendAppLog(appID, message, sourceType, sourceInstance string) error
 	SendAppErrorLog(appID, message, sourceType, sourceInstance string) error
 	SendAppMetrics(metrics *events.ContainerMetric) error

--- a/internal/v2shim/shim.go
+++ b/internal/v2shim/shim.go
@@ -57,6 +57,12 @@ func (c client) IncrementCounter(name string) error {
 	return nil
 }
 
+func (c client) IncrementCounterWithDelta(name string, value uint64) error {
+	c.client.EmitCounter(name, loggregator.WithDelta(value))
+
+	return nil
+}
+
 func (c client) SendAppLog(appID, message, sourceType, sourceInstance string) error {
 	c.client.EmitLog(
 		message,

--- a/testhelpers/fakes/v1/fake_ingress_client.go
+++ b/testhelpers/fakes/v1/fake_ingress_client.go
@@ -63,6 +63,15 @@ type FakeIngressClient struct {
 	incrementCounterReturns struct {
 		result1 error
 	}
+	IncrementCounterWithDeltaStub        func(name string, value uint64) error
+	incrementCounterWithDeltaMutex       sync.RWMutex
+	incrementCounterWithDeltaArgsForCall []struct {
+		name  string
+		value uint64
+	}
+	incrementCounterWithDeltaReturns struct {
+		result1 error
+	}
 	SendAppLogStub        func(appID, message, sourceType, sourceInstance string) error
 	sendAppLogMutex       sync.RWMutex
 	sendAppLogArgsForCall []struct {
@@ -310,6 +319,40 @@ func (fake *FakeIngressClient) IncrementCounterReturns(result1 error) {
 	}{result1}
 }
 
+func (fake *FakeIngressClient) IncrementCounterWithDelta(name string, value uint64) error {
+	fake.incrementCounterWithDeltaMutex.Lock()
+	fake.incrementCounterWithDeltaArgsForCall = append(fake.incrementCounterWithDeltaArgsForCall, struct {
+		name  string
+		value uint64
+	}{name, value})
+	fake.recordInvocation("IncrementCounterWithDelta", []interface{}{name, value})
+	fake.incrementCounterWithDeltaMutex.Unlock()
+	if fake.IncrementCounterWithDeltaStub != nil {
+		return fake.IncrementCounterWithDeltaStub(name, value)
+	} else {
+		return fake.incrementCounterWithDeltaReturns.result1
+	}
+}
+
+func (fake *FakeIngressClient) IncrementCounterWithDeltaCallCount() int {
+	fake.incrementCounterWithDeltaMutex.RLock()
+	defer fake.incrementCounterWithDeltaMutex.RUnlock()
+	return len(fake.incrementCounterWithDeltaArgsForCall)
+}
+
+func (fake *FakeIngressClient) IncrementCounterWithDeltaArgsForCall(i int) (string, uint64) {
+	fake.incrementCounterWithDeltaMutex.RLock()
+	defer fake.incrementCounterWithDeltaMutex.RUnlock()
+	return fake.incrementCounterWithDeltaArgsForCall[i].name, fake.incrementCounterWithDeltaArgsForCall[i].value
+}
+
+func (fake *FakeIngressClient) IncrementCounterWithDeltaReturns(result1 error) {
+	fake.IncrementCounterWithDeltaStub = nil
+	fake.incrementCounterWithDeltaReturns = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeIngressClient) SendAppLog(appID string, message string, sourceType string, sourceInstance string) error {
 	fake.sendAppLogMutex.Lock()
 	fake.sendAppLogArgsForCall = append(fake.sendAppLogArgsForCall, struct {
@@ -465,6 +508,8 @@ func (fake *FakeIngressClient) Invocations() map[string][][]interface{} {
 	defer fake.sendRequestsPerSecondMutex.RUnlock()
 	fake.incrementCounterMutex.RLock()
 	defer fake.incrementCounterMutex.RUnlock()
+	fake.incrementCounterWithDeltaMutex.RLock()
+	defer fake.incrementCounterWithDeltaMutex.RUnlock()
 	fake.sendAppLogMutex.RLock()
 	defer fake.sendAppLogMutex.RUnlock()
 	fake.sendAppErrorLogMutex.RLock()

--- a/v1/client.go
+++ b/v1/client.go
@@ -150,6 +150,11 @@ func (c *Client) Send() error {
 func (c *Client) IncrementCounter(name string) error {
 	return metrics.IncrementCounter(name)
 }
+
+func (c *Client) IncrementCounterWithDelta(name string, value uint64) error {
+	return metrics.AddToCounter(name, value)
+}
+
 func (c *Client) SendAppLog(appID, message, sourceType, sourceInstance string) error {
 	return logs.SendAppLog(appID, message, sourceType, sourceInstance)
 }

--- a/v1/client_test.go
+++ b/v1/client_test.go
@@ -315,6 +315,18 @@ var _ = Describe("DropsondeClient", func() {
 			Expect(metricSender.HasValue("test-name")).To(BeTrue())
 			Expect(metricSender.GetValue("test-name")).To(Equal(mfake.Metric{Value: 100.1, Unit: "Req/s"}))
 		})
+
+		It("sends component incremented counter", func() {
+			client.IncrementCounter("test-name")
+			Expect(metricSender.GetCounter("test-name")).To(Equal(uint64(1)))
+		})
+
+		It("sends component incremented counter with delta", func() {
+			client.IncrementCounter("test-name")
+			Expect(metricSender.GetCounter("test-name")).To(Equal(uint64(1)))
+			client.IncrementCounterWithDelta("test-name", 10)
+			Expect(metricSender.GetCounter("test-name")).To(Equal(uint64(11)))
+		})
 	})
 })
 


### PR DESCRIPTION
Made the following changes:
* Adds an interface method called IncrementCounterWithDelta to the IngressClient in the compatibility package
* Adds implementations in the v1  and v2shim clients
* Tests for IncrementConterWithDelta and IncrementCounter in the v1 client only as the shim does not have any unit tests