### PR TITLE
Add script to install and run linters

### DIFF
--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+function run_linters {
+    echo "Installing linters"
+    go get -u github.com/alecthomas/gometalinter
+    gometalinter --install
+
+    echo "Running Linters"
+
+    local dir
+    if [ "$1" = "" ]; then
+        go_loggregator_pkg="./..."
+    else
+        go_loggregator_pkg="$1"
+    fi
+
+    gometalinter --vendor --disable-all $go_loggregator_pkg \
+      --enable "vet" \
+      --enable "deadcode" \
+      --enable "golint" \
+      --enable "aligncheck" \
+      --enable "structcheck" \
+      --enable "varcheck" \
+      --enable "errcheck" \
+      --enable "ineffassign" \
+      --enable "interfacer" \
+      --enable "megacheck"
+
+    return 0
+}
+
+run_linters $@


### PR DESCRIPTION
This PR adds `scripts/lint` which will install and run linters using `github.com/alecthomas/gometalinter`.

The reason I opted for using `github.com/alecthomas/gometalinter` instead of a script to call each linter individually like we do in loggregator is because `gometalinter` easily supports ignoring the vendor directory.